### PR TITLE
Upgraded webpack to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^15.3.2",
     "react-native": "^0.42.0",
     "react-redux": "^3.1.2",
-    "redux": "^3.1.1",
+    "redux": "^3.6.0",
     "redux-thunk": "^1.0.3",
     "superagent": "^1.7.2"
   },
@@ -42,15 +42,14 @@
     "react-transform-catch-errors": "^1.0.1",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.3.2",
-    "redux": "^3.6.0",
     "redux-devtools": "^3.3.1",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.0.11",
     "redux-logger": "^2.4.0",
     "style-loader": "^0.13.0",
-    "webpack": "^1.12.12",
+    "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.5.1",
-    "webpack-dev-server": "^1.14.1",
+    "webpack-dev-server": "^2.4.2",
     "webpack-hot-middleware": "^2.6.4"
   }
 }

--- a/web/webpack/web.dev.config.js
+++ b/web/webpack/web.dev.config.js
@@ -4,7 +4,7 @@ const webpack = require('webpack');
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
-    'webpack-hot-middleware/client',
+    // 'webpack-hot-middleware/client',
     'babel-polyfill',
     path.join(__dirname, '../../app/web/index'),
   ],
@@ -14,24 +14,41 @@ module.exports = {
     publicPath: '/',
   },
   module: {
-    loaders: [
+    rules: [
       // take all less files, compile them, and bundle them in with our js bundle
-      { test: /\.less$/, loader: 'style!css!autoprefixer?browsers=last 2 version!less' },
+      {
+				test: /\.less$/,
+				use: [
+					'style-loader',
+					'css-loader',
+					{
+						loader: 'autoprefixer-loader',
+						options: {
+							browsers: 'last 2 version'
+						}
+					},
+					'less-loader'
+				]
+			},
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['es2015', 'react'],
-          plugins: [['react-transform', {
-            transforms: [{
-              transform: 'react-transform-hmr',
-              imports: ['react'],
-              // this is important for Webpack HMR:
-              locals: ['module']
-            }],
-          }]],
-        },
+				use: [
+					{
+						loader: 'babel-loader',
+						options: {
+							presets: ['es2015', 'react'],
+							plugins: [['react-transform', {
+								transforms: [{
+									transform: 'react-transform-hmr',
+									imports: ['react'],
+									// this is important for Webpack HMR:
+									locals: ['module']
+								}],
+							}]],
+						},
+					}
+				]
       },
     ],
   },
@@ -42,8 +59,8 @@ module.exports = {
         PLATFORM_ENV: JSON.stringify('web'),
       },
     }),
-    new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
+    // new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
+		new webpack.NamedModulesPlugin(),
   ],
 };

--- a/web/webpack/web.prod.config.js
+++ b/web/webpack/web.prod.config.js
@@ -11,16 +11,31 @@ module.exports = {
     publicPath: '/',
   },
   module: {
-    loaders: [
+		rules: [
       // take all less files, compile them, and bundle them in with our js bundle
-      { test: /\.less$/, loader: 'style!css!autoprefixer?browsers=last 2 version!less' },
+      {
+				test: /\.less$/,
+				use: [
+					'style-loader',
+					'css-loader',
+					{
+						loader: 'autoprefixer-loader',
+						options: {
+							browsers: 'last 2 version'
+						}
+					},
+					'less-loader'
+				]
+			},
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['es2015', 'react'],
-        },
+				use: [
+					loader: 'babel-loader',
+					options: {
+						presets: ['es2015', 'react'],
+					},
+				]
       },
     ],
   },
@@ -33,8 +48,6 @@ module.exports = {
       },
     }),
     // optimizations
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,


### PR DESCRIPTION
I noticed some npm packages do not transpile to ES5, so I needed webpack v2 to handle this. So I upgraded webpack to version 2 in preparation for [react-hot-loader v3](https://github.com/gaearon/react-hot-loader) ([react-transform-hmr](https://github.com/gaearon/react-transform-hmr) is deprecated) and other benefits.