### PR TITLE
Fix with json-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-react": "^6.3.13",
     "css-loader": "^0.23.1",
     "gulp": "^3.9.0",
+    "json-loader": "^0.5.4",
     "less": "^2.5.3",
     "less-loader": "^2.2.2",
     "react-native-cli": "^0.1.10",

--- a/web/webpack/web.dev.config.js
+++ b/web/webpack/web.dev.config.js
@@ -16,8 +16,13 @@ module.exports = {
   module: {
     loaders: [
       // take all less files, compile them, and bundle them in with our js bundle
-      { test: /\.less$/, loader: 'style!css!autoprefixer?browsers=last 2 version!less' },
-      {
+      { 
+        test: /\.less$/, 
+        loader: 'style!css!autoprefixer?browsers=last 2 version!less' 
+      },{
+        test: /\.json$/,
+        loader: "json",
+      },{
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'babel-loader',

--- a/web/webpack/web.prod.config.js
+++ b/web/webpack/web.prod.config.js
@@ -13,7 +13,13 @@ module.exports = {
   module: {
     loaders: [
       // take all less files, compile them, and bundle them in with our js bundle
-      { test: /\.less$/, loader: 'style!css!autoprefixer?browsers=last 2 version!less' },
+      { 
+        test: /\.less$/, 
+        loader: 'style!css!autoprefixer?browsers=last 2 version!less' 
+      },{
+        test: /\.json$/,
+        loader: "json",
+      }
       {
         test: /\.js$/,
         exclude: /node_modules/,


### PR DESCRIPTION
I tried to import [Grommet-lib](https://grommet.github.io/) components, but webpack shows an error with some json-files in the lib.
These few changes fix the problem and it works and compiles well.
I've seen the following links:
https://github.com/webpack-contrib/json-loader/issues/17
https://github.com/grommet/grommet/issues/855
https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/110
... and then made this pull-request.
Btw, thank you for the bundle.